### PR TITLE
feat: Option to make workers lazily created

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ var fs = require('fs'),
     path = require('path'),
     paths = new Map();
 
-module.exports = function () {
+module.exports = function (userOptions) {
+    userOptions = userOptions || {};
     return {
         resolveId: function (importee, importer) {
             if (importee === 'rollup-plugin-bundle-worker') {
@@ -26,9 +27,13 @@ module.exports = function () {
                 return;
             }
 
+            const lazy = userOptions.lazy ? '() =>' : '';
+
+            exportLine = `export default ${lazy} new shimWorker(${JSON.stringify(paths.get(id))}, function (window, document) {`,
+
             var code = [
                     `import shimWorker from 'rollup-plugin-bundle-worker';`,
-                    `export default new shimWorker(${JSON.stringify(paths.get(id))}, function (window, document) {`,
+                    exportLine,
                     `var self = this;`,
                     fs.readFileSync(id, 'utf-8'),
                     `\n});`


### PR DESCRIPTION
Saves about ~1-5ms per worker at script start time and 1.5ms for the worker test we are doing at startup that is pushed off until `shimWorker` is used for the first time.